### PR TITLE
Force the order of images displayed in control.

### DIFF
--- a/js/customize-image-gallery-control.js
+++ b/js/customize-image-gallery-control.js
@@ -54,6 +54,16 @@
 
                 var value = control.setting.get();
                 control.setAttachmentsData( value ).done( function() {
+                    function idComparator( a, b ) {
+                        if ( a.id < b.id ) {
+                            return 1
+                        } else if ( a.id > b.id ) {
+                            return -1;
+                        } else {
+                            return 0;
+                        }
+                    }
+                    control.params.attachments.sort( idComparator );
                     control.renderContent();
                 } );
             }

--- a/js/customize-image-gallery-control.js
+++ b/js/customize-image-gallery-control.js
@@ -56,7 +56,7 @@
                 control.setAttachmentsData( value ).done( function() {
                     function idComparator( a, b ) {
                         if ( a.id < b.id ) {
-                            return 1
+                            return 1;
                         } else if ( a.id > b.id ) {
                             return -1;
                         } else {


### PR DESCRIPTION
Ensure that images in the control are displayed in the same order as in media library. Since the sorting is not implemented right now, this PR will force the attachments displayed in the same order as displayed in media library.
