### PR TITLE
JS script fix for solving an issue of broken drag and drop sorting fe…

### DIFF
--- a/js/customize-image-gallery-control.js
+++ b/js/customize-image-gallery-control.js
@@ -207,7 +207,7 @@
          */
         setupSortable: function() {
             var control = this,
-                list = $( '.image-gallery-attachments' );
+                list = $(this.container).find( '.image-gallery-attachments' );
             list.sortable({
                 items: '.image-gallery-thumbnail-wrapper',
                 tolerance: 'pointer',


### PR DESCRIPTION
There is an issue when you try to use more than one gallery control in the same customizer. Basically everything works fine except drag and drop sorting feature.

Since the selector in the JS file is wrong it grabs all of the IDs of the images on drag event & stacks it to the data of the last gallery control. That behavior leads to multiplying images of the last gallery. 

Moreover, it's hard to notice if you sorting upper galleries located in different tabs because visually it looks fine except that when you open the tab with the last gallery control which is a total mess.